### PR TITLE
Fix multipart uploads

### DIFF
--- a/packages/signalk-plugin/package.json
+++ b/packages/signalk-plugin/package.json
@@ -50,7 +50,6 @@
     "cron": "^4.3.4",
     "csv-parse": "^5.6.0",
     "debug": "^4.4.3",
-    "form-data": "^4.0.4",
     "geojson": "^0.5.0",
     "geolib": "^3.3.4",
     "json-stream-stringify": "^3.1.6",


### PR DESCRIPTION
Vercel returns a 500 error under some circumstates that I can't reproduce, which has to do with the chunked multipart uploads.

This switches from `form-data` package, which streams data using chunked encoding, to the built-in `FormData` object. This requires the reporter to read the entire contents into memory before reporting, which could be 10-20MB of geojson.

I had originally written this library to make heavy use of streams, but with both the history API and this not using streams, it's probably worth revisiting that choice.