### PR TITLE
Report in 6 hour increments to limit file size

### DIFF
--- a/packages/signalk-plugin/src/constants.ts
+++ b/packages/signalk-plugin/src/constants.ts
@@ -18,14 +18,23 @@ export const ENV =
   (isInstalledAsModule && "production") ||
   "development";
 
-export const {
-  BATHY_URL = ENV === "production"
+/** The URL to report data to */
+export const BATHY_URL =
+  process.env.BATHY_URL ||
+  (ENV === "production"
     ? "https://depth.openwaters.io"
-    : "http://localhost:3001",
-  BATHY_DEFAULT_SCHEDULE = "0 0 * * *", // every day at midnight
-} = process.env;
+    : "http://localhost:3001");
 
-// Earliest date for bathymetry data. signalk-to-influxdb was first released on 2017-06-28
+/** Number of hours of data to report in each submission */
+export const BATHY_WINDOW_SIZE = Temporal.Duration.from({
+  hours: Number(process.env.BATHY_WINDOW_SIZE ?? 6),
+});
+
+/** Cron schedule to report bathy */
+export const BATHY_DEFAULT_SCHEDULE =
+  process.env.BATHY_DEFAULT_SCHEDULE ?? `0 0/${BATHY_WINDOW_SIZE.hours} * * *`;
+
+/** Earliest date for bathymetry data. signalk-to-influxdb was first released on 2017-06-28 */
 export const BATHY_EPOCH = Temporal.Instant.from(
   process.env.BATHY_EPOCH ?? "2017-06-28T00:00:00Z",
 );

--- a/packages/signalk-plugin/test/sources/sqlite.test.ts
+++ b/packages/signalk-plugin/test/sources/sqlite.test.ts
@@ -5,6 +5,7 @@ import { pipeline } from "stream/promises";
 import { app } from "../helper.js";
 import { createDB } from "../../src/storage.js";
 import { Temporal } from "@js-temporal/polyfill";
+import { Timeframe } from "../../src/types.js";
 
 const data = [
   {
@@ -36,11 +37,13 @@ test("reading and writing to sqlite", async () => {
   const writer = source.createWriter!();
   await pipeline(Readable.from(data), writer);
 
-  const reader = await source.createReader({
-    from: Temporal.Instant.fromEpochMilliseconds(0),
-    to: Temporal.Now.instant(),
-  });
-  const result = await reader.toArray();
+  const reader = await source.createReader(
+    new Timeframe(
+      Temporal.Instant.fromEpochMilliseconds(0),
+      Temporal.Now.instant(),
+    ),
+  );
+  const result = await reader!.toArray();
   expect(result.length).toBe(data.length);
   expect(result[0]).toEqual(data[0]);
   expect(result[1]).toEqual({ ...data[1], heading: null });
@@ -52,12 +55,14 @@ test("reading with from and to", async () => {
   const writer = source.createWriter!();
   await pipeline(Readable.from(data), writer);
 
-  const reader = await source.createReader({
-    from: Temporal.Instant.from("2025-08-06T22:30:00.000Z"),
-    to: Temporal.Instant.from("2025-08-06T23:30:00.000Z"),
-  });
+  const reader = await source.createReader(
+    new Timeframe(
+      Temporal.Instant.from("2025-08-06T22:30:00.000Z"),
+      Temporal.Instant.from("2025-08-06T23:30:00.000Z"),
+    ),
+  );
 
-  const result = await reader.toArray();
+  const result = await reader!.toArray();
   expect(result.length).toBe(1);
   expect(result[0].timestamp).toEqual(data[1].timestamp);
 });
@@ -65,10 +70,84 @@ test("reading with from and to", async () => {
 test("reading with no data", async () => {
   const source = createSqliteSource(app, createDB(":memory:"));
 
-  const reader = await source.createReader({
-    from: new Date("2025-08-06T22:30:00.000Z"),
-    to: new Date("2025-08-06T23:30:00.000Z"),
-  });
+  const reader = await source.createReader(
+    new Timeframe(
+      Temporal.Instant.from("2025-08-06T22:30:00.000Z"),
+      Temporal.Instant.from("2025-08-06T23:30:00.000Z"),
+    ),
+  );
 
   expect(reader).toBeUndefined();
+});
+
+function point(
+  ts: string,
+  extra: Partial<{
+    latitude: number;
+    longitude: number;
+    depth: number;
+    heading: number | undefined;
+  }> = {},
+) {
+  return {
+    latitude: 1,
+    longitude: 2,
+    depth: 3,
+    timestamp: Temporal.Instant.from(ts),
+    ...extra,
+  };
+}
+
+test("getAvailableTimeframes returns 6-hour windows with data", async () => {
+  const db = createDB(":memory:");
+  const source = createSqliteSource(app, db);
+  const writer = source.createWriter!();
+
+  const data = [
+    point("2025-01-01T01:00:00Z"), // bucket [00:00, 06:00)
+    point("2025-01-01T07:30:00Z"), // bucket [06:00, 12:00)
+    point("2025-01-02T00:30:00Z"), // bucket [00:00, 06:00) next day
+  ];
+
+  await pipeline(Readable.from(data), writer);
+
+  const from = Temporal.Instant.from("2025-01-01T00:00:00Z");
+  const to = Temporal.Instant.from("2025-01-03T00:00:00Z");
+  const windowSize = Temporal.Duration.from({ hours: 6 });
+
+  const windows = await source.getAvailableTimeframes!(
+    new Timeframe(from, to),
+    windowSize,
+  );
+  expect(windows).toHaveLength(3);
+
+  expect(windows[0].from).toEqual(
+    Temporal.Instant.from("2025-01-01T00:00:00Z"),
+  );
+  expect(windows[0].to).toEqual(Temporal.Instant.from("2025-01-01T06:00:00Z"));
+
+  expect(windows[1].from).toEqual(
+    Temporal.Instant.from("2025-01-01T06:00:00Z"),
+  );
+  expect(windows[1].to).toEqual(Temporal.Instant.from("2025-01-01T12:00:00Z"));
+
+  expect(windows[2].from).toEqual(
+    Temporal.Instant.from("2025-01-02T00:00:00Z"),
+  );
+  expect(windows[2].to).toEqual(Temporal.Instant.from("2025-01-02T06:00:00Z"));
+});
+
+test("getAvailableTimeframes returns empty for no data", async () => {
+  const db = createDB(":memory:");
+  const source = createSqliteSource(app, db);
+
+  const from = Temporal.Instant.from("2025-01-01T00:00:00Z");
+  const to = Temporal.Instant.from("2025-01-02T00:00:00Z");
+  const windowSize = Temporal.Duration.from({ hours: 6 });
+
+  const windows = await source.getAvailableTimeframes!(
+    new Timeframe(from, to),
+    windowSize,
+  );
+  expect(windows).toHaveLength(0);
 });


### PR DESCRIPTION
Refactors history reporting to accept a window (default 6 hours) for reporting. 

By my tests, the file size of a full 6 hours of data (21,600 points) is about 3MB.