### PR TITLE
Switch from better-sqlite3 to Node.js built-in node:sqlite

### DIFF
--- a/packages/signalk-plugin/package.json
+++ b/packages/signalk-plugin/package.json
@@ -38,15 +38,16 @@
     "lint": "tsc -b && publint --strict",
     "test": "vitest"
   },
+  "engines": {
+    "node": ">=22.13.0"
+  },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
     "@types/geojson": "^7946.0.16",
     "publint": "^0.3.16"
   },
   "dependencies": {
     "@js-temporal/polyfill": "^0.5",
     "@signalk/server-api": "^2.10.2",
-    "better-sqlite3": "^12.4.1",
     "cron": "^4.3.4",
     "csv-parse": "^5.6.0",
     "debug": "^4.4.3",

--- a/packages/signalk-plugin/src/metadata.ts
+++ b/packages/signalk-plugin/src/metadata.ts
@@ -22,10 +22,12 @@ export async function getVesselInfo(app: ServerAPI): Promise<VesselInfo> {
     ...(await identify(app)),
     // @ts-expect-error remove after next signalk release
     mmsi: app.config.vesselMMSI,
-    imo: app.getSelfPath("registrations.imo"),
-    name: app.getSelfPath("name"),
-    loa: app.getSelfPath("design.length.value")?.overall,
-    type: app.getSelfPath("design.aisShipType.value")?.name,
+    imo: app.getSelfPath("registrations.imo") as string | undefined,
+    name: app.getSelfPath("name") as string | undefined,
+    loa: (app.getSelfPath("design.length.value") as { overall?: number })
+      ?.overall,
+    type: (app.getSelfPath("design.aisShipType.value") as { name?: string })
+      ?.name,
   };
 }
 

--- a/packages/signalk-plugin/src/reporters/index.ts
+++ b/packages/signalk-plugin/src/reporters/index.ts
@@ -10,7 +10,7 @@ import {
   BATHY_EPOCH,
   BATHY_WINDOW_SIZE,
 } from "../constants.js";
-import type { Database } from "better-sqlite3";
+import type { DatabaseSync } from "node:sqlite";
 import { Temporal } from "@js-temporal/polyfill";
 import { Status } from "../status.js";
 
@@ -20,7 +20,7 @@ export interface ReporterOptions {
   app: ServerAPI;
   config: Config;
   source: BathymetrySource;
-  db: Database;
+  db: DatabaseSync;
   status: Status;
   signal: AbortSignal;
   schedule?: string; // cron schedule string
@@ -133,11 +133,11 @@ export function createReporter({
   }
 }
 
-export function createReportLogger(db: Database) {
+export function createReportLogger(db: DatabaseSync) {
   const insert = db.prepare(
     `INSERT INTO reports(fromTimestamp, toTimestamp) VALUES(?, ?)`,
   );
-  const select = db.prepare<[], { toTimestamp: number }>(
+  const select = db.prepare(
     `SELECT toTimestamp FROM reports ORDER BY toTimestamp DESC LIMIT 1`,
   );
 
@@ -146,7 +146,7 @@ export function createReportLogger(db: Database) {
       insert.run(from.epochMilliseconds, to.epochMilliseconds);
     },
     get lastReport() {
-      const row = select.get();
+      const row = select.get() as { toTimestamp: number } | undefined;
       return row
         ? Temporal.Instant.fromEpochMilliseconds(row.toTimestamp)
         : undefined;

--- a/packages/signalk-plugin/src/sources/history.ts
+++ b/packages/signalk-plugin/src/sources/history.ts
@@ -31,15 +31,21 @@ export async function createHistorySource(
       to,
       resolution: 1, // 1 second,
       pathSpecs: [
-        { path: "navigation.position" as Path, aggregate: "first" },
+        {
+          path: "navigation.position" as Path,
+          aggregate: "first",
+          parameter: [],
+        },
         {
           path: `environment.depth.${config.path}` as Path,
           // signalk-to-influxdb returns null when requesting `first`, so using `min` instead
           aggregate: "min",
+          parameter: [],
         },
         {
           path: "navigation.headingTrue" as Path,
           aggregate: "average",
+          parameter: [],
         },
       ],
     };
@@ -59,8 +65,13 @@ export async function createHistorySource(
 
     const data = res.data
       .map((row): BathymetryData | undefined => {
-        const [timestamp, position, depth, heading] = row;
-        const [longitude, latitude] = position || [];
+        const [timestamp, position, depth, heading] = row as unknown as [
+          string,
+          [number, number] | null,
+          number,
+          number | undefined,
+        ];
+        const [longitude, latitude] = position ?? [NaN, NaN];
 
         if (
           Number.isFinite(depth) &&
@@ -102,6 +113,7 @@ export async function createHistorySource(
           path: ("environment.depth." + config.path) as Path,
           // signalk-to-influxdb returns null when requesting `first`, so using `min` instead
           aggregate: "min",
+          parameter: [],
         },
       ],
     });

--- a/packages/signalk-plugin/src/sources/sqlite.ts
+++ b/packages/signalk-plugin/src/sources/sqlite.ts
@@ -1,4 +1,4 @@
-import Database from "better-sqlite3";
+import { DatabaseSync, StatementSync } from "node:sqlite";
 import { BathymetryData, BathymetrySource, Timeframe } from "../types.js";
 import { Readable, Writable } from "stream";
 import { ServerAPI } from "@signalk/server-api";
@@ -16,7 +16,7 @@ type BathymetryRow = {
 
 export function createSqliteSource(
   app: ServerAPI,
-  db: Database.Database,
+  db: DatabaseSync,
 ): BathymetrySource {
   app.debug(`Using SQLite source`);
 
@@ -32,10 +32,7 @@ export function createSqliteSource(
       const toMs = timeframe.to.epochMilliseconds;
       const bucketMs = windowSize.total("milliseconds");
 
-      const stmt = db.prepare<
-        { from: number; to: number; bucket: number },
-        { idx: number }
-      >(
+      const stmt = db.prepare(
         `
           SELECT CAST(((timestamp - :from) / :bucket) AS INTEGER) AS idx
           FROM bathymetry
@@ -45,7 +42,9 @@ export function createSqliteSource(
         `,
       );
 
-      const rows = stmt.all({ from: fromMs, to: toMs, bucket: bucketMs });
+      const rows = stmt.all({ from: fromMs, to: toMs, bucket: bucketMs }) as {
+        idx: number;
+      }[];
 
       return rows.map(({ idx }) => {
         const start = Temporal.Instant.fromEpochMilliseconds(
@@ -64,15 +63,8 @@ export interface SqliteReaderOptions {
   to?: Temporal.Instant;
 }
 
-type QueryOptions = {
-  limit: number;
-  offset: number;
-  from?: number;
-  to?: number;
-};
-
 export function createSqliteReader(
-  db: Database.Database,
+  db: DatabaseSync,
   options: SqliteReaderOptions = {},
 ) {
   const {
@@ -82,16 +74,18 @@ export function createSqliteReader(
   } = options;
 
   const { count } = db
-    .prepare<
-      { from: number; to: number },
-      { count: number }
-    >(`SELECT count(*) as count FROM bathymetry WHERE timestamp >= :from AND timestamp <= :to`)
-    .get({ from: from.epochMilliseconds, to: to.epochMilliseconds })!;
+    .prepare(
+      `SELECT count(*) as count FROM bathymetry WHERE timestamp >= :from AND timestamp <= :to`,
+    )
+    .get({
+      from: from.epochMilliseconds,
+      to: to.epochMilliseconds,
+    }) as { count: number };
 
   if (count <= 0) return;
 
   let offset = 0;
-  let query: Database.Statement<QueryOptions, BathymetryRow>;
+  let query: StatementSync;
 
   return new Readable({
     objectMode: true,
@@ -114,7 +108,7 @@ export function createSqliteReader(
         offset,
         from: from.epochMilliseconds,
         to: to.epochMilliseconds,
-      });
+      }) as BathymetryRow[];
 
       rows.forEach(({ longitude, latitude, depth, timestamp, heading }) => {
         this.push({
@@ -133,8 +127,8 @@ export function createSqliteReader(
   });
 }
 
-export function createSqliteWriter(db: Database.Database) {
-  let stmt: Database.Statement<Omit<BathymetryRow, "id">>;
+export function createSqliteWriter(db: DatabaseSync) {
+  let stmt: StatementSync;
 
   return new Writable({
     objectMode: true,

--- a/packages/signalk-plugin/src/storage.ts
+++ b/packages/signalk-plugin/src/storage.ts
@@ -47,7 +47,11 @@ export function runMigrations(db: DatabaseSync, migrations: Migration[]) {
       db.exec(`PRAGMA user_version = ${version + i + 1}`);
       db.exec("COMMIT");
     } catch (err) {
-      db.exec("ROLLBACK");
+      try {
+        db.exec("ROLLBACK");
+      } catch {
+        // Ignore rollback failures to avoid masking the original error.
+      }
       throw err;
     }
   });

--- a/packages/signalk-plugin/src/storage.ts
+++ b/packages/signalk-plugin/src/storage.ts
@@ -1,8 +1,8 @@
-import Database from "better-sqlite3";
+import { DatabaseSync } from "node:sqlite";
 
-export function createDB(filename: string): Database.Database {
-  const db = new Database(filename);
-  db.pragma("journal_mode = WAL");
+export function createDB(filename: string): DatabaseSync {
+  const db = new DatabaseSync(filename);
+  db.exec("PRAGMA journal_mode = WAL");
 
   runMigrations(db, [
     () => {
@@ -34,14 +34,21 @@ export function createDB(filename: string): Database.Database {
   return db;
 }
 
-export type Migration = (db: Database.Database) => void;
+export type Migration = (db: DatabaseSync) => void;
 
-export function runMigrations(db: Database.Database, migrations: Migration[]) {
-  const version = db.pragma("user_version", { simple: true }) as number;
+export function runMigrations(db: DatabaseSync, migrations: Migration[]) {
+  const { user_version: version } = db.prepare("PRAGMA user_version").get() as {
+    user_version: number;
+  };
   migrations.slice(version).forEach((migration, i) => {
-    db.transaction(() => {
+    db.exec("BEGIN");
+    try {
       migration(db);
-      db.pragma(`user_version = ${version + i + 1}`);
-    })();
+      db.exec(`PRAGMA user_version = ${version + i + 1}`);
+      db.exec("COMMIT");
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw err;
+    }
   });
 }

--- a/packages/signalk-plugin/src/streams/live.ts
+++ b/packages/signalk-plugin/src/streams/live.ts
@@ -35,8 +35,14 @@ export function createLiveStream(app: ServerAPI, config: Config) {
         const timestamp = Temporal.Instant.from(
           update.timestamp ?? Temporal.Now.instant(),
         );
-        const position = app.getSelfPath("navigation.position");
-        let heading = app.getSelfPath("navigation.headingTrue");
+        const position = app.getSelfPath("navigation.position") as
+          | {
+              value: { longitude: number; latitude: number };
+              timestamp: string;
+            }
+          | undefined;
+        let heading = app.getSelfPath("navigation.headingTrue") as
+          { value: number; timestamp: string } | undefined;
 
         if ("values" in update) {
           update.values.forEach(({ value }) => {


### PR DESCRIPTION
Fixes #76

## What

Replaces `better-sqlite3` with Node's built-in [`node:sqlite`](https://nodejs.org/api/sqlite.html) module.

`better-sqlite3` has a native postinstall build step, which violates the [Signal K policy against install-time scripts](https://demo.signalk.org/documentation/Developing/Plugins/Publishing_to_The_AppStore.html#important-avoid-install-time-scripts). `node:sqlite` is built in (no compile, no `npm run install` dance after every install).

## Changes

- `storage.ts`, `sources/sqlite.ts`, `reporters/index.ts`: `better-sqlite3` → `node:sqlite` (`DatabaseSync`/`StatementSync`).
  - `db.pragma(...)` → `PRAGMA` statements via `exec`/`prepare`
  - `db.transaction(fn)()` → manual `BEGIN`/`COMMIT`/`ROLLBACK`
  - statement generics → result casts (`node:sqlite` statements aren't generic)
- `package.json`: drop `better-sqlite3` + `@types/better-sqlite3`; add `engines: { node: ">=22.13.0" }` — the version where `node:sqlite` works without `--experimental-sqlite` (a plugin can't pass node flags to signalk-server).
- Drive-by: fixed pre-existing build errors from newer `@signalk/server-api` types (`getSelfPath` now returns `unknown`; `PathSpec` requires `parameter`) in `metadata.ts`, `sources/history.ts`, `streams/live.ts`.

## Notes

- `node:sqlite` prints a one-time `ExperimentalWarning` at runtime on Node 22–25. Harmless; clears when the module stabilizes.

## Testing

- `npm run build` clean
- All 40 tests pass (`npm test`)