### PR TITLE
Upgrade API to Express 5

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/busboy": "^1.5.4",
-    "@types/express": "^4.17.21",
+    "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/semver": "^7.7.1",
     "@types/supertest": "^6.0.3",
@@ -25,7 +25,7 @@
     "@aws-sdk/client-s3": "^3.940.0",
     "busboy": "^1.6.0",
     "crowd-depth": "*",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "express-async-handler": "^1.2.0",
     "jsonwebtoken": "^9.0.2",
     "pino": "^10.2.1",


### PR DESCRIPTION
Upgrades the API to Express 5, consolidating the two Dependabot bumps (#22 express, #24 @types/express) into one atomic change so they land together.

## Changes
- `packages/api`: bump `express` to `^5.2.1` and `@types/express` to `^5.0.6`

No code changes were needed. The API's routes are static or named-param only, it doesn't mutate `req.query`, and there's a single Express in the tree, so the default-exported `app` type stays portable (no annotation required, unlike openwaters.io).

## Testing
- `npm run build` (`tsc -b`, with declaration emit) passes — note this isn't in the current CI checks (Lint/Tests/Vercel only), so it's worth calling out
- 43/43 tests pass on Express 5
