### PR TITLE
Upgrade to TypeScript 6 and ESLint 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,19 +11,19 @@
     "start": "npm run start -w crowd-depth-api"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.1",
+    "@eslint/js": "^10.0.1",
     "@types/debug": "^4.1.12",
     "@types/node": "^26.1.0",
     "ajv": "^8.17.1",
-    "eslint": "^9.39.1",
+    "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",
     "nock": "^14.0.10",
     "prettier": "^3.6.2",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "^8.46.3",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.63.0",
     "vitest": "^4.0.8"
   },
   "lint-staged": {


### PR DESCRIPTION
Upgrades the dev tooling to TypeScript 6 and ESLint 10.

## Changes
- `typescript` 5.9.3 → ^6.0.3
- `eslint` 9 → ^10.6.0, `@eslint/js` 9 → ^10.0.1
- `typescript-eslint` 8.46 → ^8.63.0 — the enabling bump. 8.63 is the first release that supports both ESLint 10 and TypeScript 6 (`typescript <6.1.0`). Dependabot filed the eslint bumps but not this one, so they couldn't pass on their own.

No code changes needed — the repo is already on flat config (`eslint.config.mjs`).

## Verified
- `npm run check` (eslint + prettier + tsc -b + publint): passes
- 43/43 tests pass

Note: ESLint 10 requires Node >=20.19 / 22.13 / 24.

Supersedes #68 (typescript), #81 (eslint), #56 (@eslint/js).
