### PR TITLE
Use ISO 8601 for report timestamps in plugin status

### DIFF
--- a/packages/signalk-plugin/src/status.ts
+++ b/packages/signalk-plugin/src/status.ts
@@ -16,9 +16,8 @@ export function createStatus(app: ServerAPI) {
       [
         state.collecting && "Collecting bathymetry",
         state.usingHistory && "Using history",
-        state.lastReport && `Reported at ${state.lastReport.toLocaleString()}`,
-        state.nextReport &&
-          `Next report at ${state.nextReport.toLocaleString()}`,
+        state.lastReport && `Reported at ${state.lastReport.toString()}`,
+        state.nextReport && `Next report at ${state.nextReport.toString()}`,
       ]
         .filter(Boolean)
         .join(", ") || "Idle"


### PR DESCRIPTION
Fixes #61.

The status line formatted `lastReport` and `nextReport` with `toLocaleString()`, so the output depended on the host's locale. On appliances like Victron VenusOS, `LANG` is unset and Node falls back to `en-US`, producing `7/13/2026, 6:00:01 PM`. That's inconsistent with the ISO 8601 timestamps every other Signal K plugin emits, and it's awkward to fix on Venus (read-only rootfs, no user-facing locale setting).

These are `Temporal.Instant` values, so `.toString()` already returns ISO 8601. Switching to it drops the locale dependency and lines up with the surrounding plugins.

Before: `Reported at 7/13/2026, 6:00:01 PM`
After: `Reported at 2026-07-13T18:00:01Z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)