### PR TITLE
Reduce disk sync frequency to limit SD card wear

### DIFF
--- a/packages/signalk-plugin/src/storage.ts
+++ b/packages/signalk-plugin/src/storage.ts
@@ -3,6 +3,9 @@ import { DatabaseSync } from "node:sqlite";
 export function createDB(filename: string): DatabaseSync {
   const db = new DatabaseSync(filename);
   db.exec("PRAGMA journal_mode = WAL");
+  // Skip per-commit fsync so 1Hz depth inserts don't wear out SD cards (#100).
+  // WAL + NORMAL is durable against corruption; worst case loses recent rows on power loss.
+  db.exec("PRAGMA synchronous = NORMAL");
 
   runMigrations(db, [
     () => {


### PR DESCRIPTION
Fixes #100.

Every depth reading was inserted in its own autocommit transaction, and each commit fsyncs the WAL file. With a sounder emitting at 1Hz or faster, that's at least one forced disk write per second, which is what @hoeken observed wearing out SD cards.

This sets `PRAGMA synchronous = NORMAL`, the recommended setting for WAL mode. SQLite then only fsyncs at checkpoints, so per-second inserts land in the OS page cache and the kernel batches them onto disk on its own writeback schedule. The database can't corrupt in this mode; the worst case on power loss is losing the last few seconds of readings, which seems acceptable for crowdsourced bathymetry.

I considered buffering rows in memory and committing on a 1-2 minute timer as the issue suggests, but that adds shutdown/flush logic and hides buffered rows from readers until flush. The pragma addresses the underlying hardware concern (fsync frequency) without changing any observable behavior. If WAL churn still proves too much on some hardware, batched commits plus a larger `wal_autocheckpoint` would be the follow-up.