### PR TITLE
Record submission outcomes and improve error reporting

### DIFF
--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -4,10 +4,10 @@ import { v4 as uuidv4 } from "uuid";
 import jwt from "jsonwebtoken";
 import busboy from "busboy";
 import { text } from "stream/consumers";
-import { submitFormData } from "crowd-depth";
+import { submitFormData, SubmissionError } from "crowd-depth";
 import { Readable } from "stream";
 import { createReadStream, createWriteStream } from "fs";
-import { unlink } from "fs/promises";
+import { stat, unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createS3Storage, S3Config } from "./s3.js";
@@ -105,10 +105,24 @@ export function registerWithRouter(router: IRouter, options: APIOptions = {}) {
       try {
         // Pipe the data to a temp file
         await pipeline(data, createWriteStream(tempFile));
+        const { size: bytes } = await stat(tempFile);
 
-        // Stream from the temp file to both NOAA and S3
-        const [submission] = await Promise.all([
-          submitFormData(
+        // Store the data before submitting so a copy is kept even when NOAA
+        // rejects it. Failing here fails the request so the client retries.
+        const key = await storage?.store(uuid, tempFile);
+
+        // Record the outcome next to the stored data; diagnosable long after
+        // Vercel's log retention expires.
+        const recordResult = (result: object) =>
+          key
+            ? storage?.storeResult(key, result).catch((err) => {
+                logger.error(err, "Failed to store submission result to S3");
+              })
+            : undefined;
+
+        const started = Date.now();
+        try {
+          const submission = await submitFormData(
             new URL("geojson", url),
             uuid,
             metadata,
@@ -116,11 +130,51 @@ export function registerWithRouter(router: IRouter, options: APIOptions = {}) {
             {
               "x-auth-token": token,
             },
-          ),
-          storage?.store(uuid, tempFile),
-        ]);
+          );
+          const durationMs = Date.now() - started;
 
-        res.json(submission);
+          logger.info(
+            { uuid, uniqueID, bytes, durationMs },
+            "NOAA submission succeeded",
+          );
+          await recordResult({
+            success: true,
+            uuid,
+            uniqueID,
+            bytes,
+            durationMs,
+            submission,
+          });
+
+          res.json(submission);
+        } catch (err) {
+          const durationMs = Date.now() - started;
+          const upstream = err instanceof SubmissionError;
+          const noaaStatus = upstream ? err.status : undefined;
+
+          logger.error(
+            { err, uuid, uniqueID, bytes, durationMs, noaaStatus },
+            "NOAA submission failed",
+          );
+          await recordResult({
+            success: false,
+            uuid,
+            uniqueID,
+            bytes,
+            durationMs,
+            noaaStatus,
+            noaaBody: upstream ? err.body : undefined,
+            message: (err as Error).message,
+          });
+
+          // 502 distinguishes upstream NOAA failures from bugs in this API.
+          // submissionId is the storage key of the archived data + result.
+          res.status(upstream ? 502 : 500).json({
+            success: false,
+            message: (err as Error).message,
+            submissionId: key,
+          });
+        }
       } catch (err) {
         logger.error(err);
         res

--- a/packages/api/src/s3.ts
+++ b/packages/api/src/s3.ts
@@ -33,8 +33,9 @@ export class S3Storage {
    * Store metadata and data files in the S3-compatible storage
    * @param uuid - The uuid of the vessel
    * @param tempFilePath - Path to the temporary geojson file
+   * @returns the key the file was stored under
    */
-  async store(uuid: string, tempFilePath: string): Promise<void> {
+  async store(uuid: string, tempFilePath: string): Promise<string> {
     const key = generateKey(uuid);
 
     logger.debug("Storing to S3 with key %s", key);
@@ -45,6 +46,23 @@ export class S3Storage {
         Key: `${key}.geojson`,
         Body: createReadStream(tempFilePath),
         ContentType: "application/geo+json",
+      }),
+    );
+
+    return key;
+  }
+
+  /**
+   * Record the submission outcome alongside the stored data so failures
+   * remain diagnosable after Vercel's short log retention expires.
+   */
+  async storeResult(key: string, result: object): Promise<void> {
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: `${key}.result.json`,
+        Body: JSON.stringify(result),
+        ContentType: "application/json",
       }),
     );
   }

--- a/packages/api/test/api.test.ts
+++ b/packages/api/test/api.test.ts
@@ -189,31 +189,53 @@ describe("POST /geojson", () => {
     expect(scope.isDone()).toBe(true);
   });
 
-  test("stores data to S3-compatible endpoint", async () => {
-    // Point storage at our mocked S3 endpoint
-    const env = {
-      S3_ENDPOINT: "https://s3.example.com",
-      S3_REGION: "us-east-1",
-      S3_ACCESS_KEY_ID: "test-key",
-      S3_SECRET_ACCESS_KEY: "test-secret",
-      S3_BUCKET: "test-bucket",
-    };
+  test("returns 502 when NOAA rejects the submission", async () => {
+    const scope = nock("https://example.com")
+      .post("/geojson")
+      .reply(500, {
+        formErrors: ["Internal Server Error"],
+        fieldErrors: {},
+        message: "Internal Server Error",
+        success: false,
+      });
 
     const uniqueID = toUniqueID(vessel);
 
-    // Mock NOAA endpoint
-    const noaaScope = nock("https://example.com")
+    await useApp()
       .post("/geojson")
-      .matchHeader("x-auth-token", "test-token")
-      .reply(200, SUCCESS_RESPONSE, { "Content-Type": "application/json" });
+      .set("Authorization", `Bearer ${createIdentity(vessel.uuid).token}`)
+      .set(
+        "User-Agent",
+        `crowd-depth/${MIN_CLIENT_VERSION} (https://github.com/openwatersio/crowd-depth)`,
+      )
+      .field("metadataInput", JSON.stringify({ uniqueID }), {
+        filename: "test.json",
+        contentType: "application/json",
+      })
+      .field("file", "dummy data", {
+        filename: "test.json",
+        contentType: "application/geo+json",
+      })
+      .expect(502)
+      .expect((res) => {
+        expect(res.body.success).toBe(false);
+        expect(res.body.message).toMatch(/500 Internal Server Error/);
+      });
 
-    // Mock S3 PUT requests - AWS SDK signs and uses specific paths
-    // We need to be lenient with the matching since AWS SDK adds auth headers
-    const s3Scope = nock(env.S3_ENDPOINT)
-      .put(/^\/test-bucket\/\d{4}\/\d{2}\/\d{2}\/.*\.geojson\?x-id=PutObject$/)
-      .reply(200);
+    expect(scope.isDone()).toBe(true);
+  });
 
-    await useApp({ env })
+  // Point storage at our mocked S3 endpoint
+  const s3Env = {
+    S3_ENDPOINT: "https://s3.example.com",
+    S3_REGION: "us-east-1",
+    S3_ACCESS_KEY_ID: "test-key",
+    S3_SECRET_ACCESS_KEY: "test-secret",
+    S3_BUCKET: "test-bucket",
+  };
+
+  function postGeoJSON(uniqueID: string) {
+    return useApp({ env: s3Env })
       .post("/geojson")
       .set("Authorization", `Bearer ${createIdentity(vessel.uuid).token}`)
       .set(
@@ -227,12 +249,108 @@ describe("POST /geojson", () => {
       .field("file", "dummy data", {
         filename: "test.xyz",
         contentType: "application/geo+json",
+      });
+  }
+
+  test("stores data and result to S3-compatible endpoint", async () => {
+    const uniqueID = toUniqueID(vessel);
+
+    // Mock NOAA endpoint
+    const noaaScope = nock("https://example.com")
+      .post("/geojson")
+      .matchHeader("x-auth-token", "test-token")
+      .reply(200, SUCCESS_RESPONSE, { "Content-Type": "application/json" });
+
+    // Mock S3 PUT requests - AWS SDK signs and uses specific paths
+    // We need to be lenient with the matching since AWS SDK adds auth headers
+    const s3Scope = nock(s3Env.S3_ENDPOINT)
+      .put(/^\/test-bucket\/\d{4}\/\d{2}\/\d{2}\/.*\.geojson\?x-id=PutObject$/)
+      .reply(200);
+
+    let result: Record<string, unknown> | undefined;
+    const resultScope = nock(s3Env.S3_ENDPOINT)
+      .put(/\.result\.json\?x-id=PutObject$/, (body) => {
+        result = body as Record<string, unknown>;
+        return true;
       })
-      .expect(200)
-      .expect(SUCCESS_RESPONSE);
+      .reply(200);
+
+    await postGeoJSON(uniqueID).expect(200).expect(SUCCESS_RESPONSE);
 
     expect(noaaScope.isDone()).toBe(true);
     expect(s3Scope.isDone()).toBe(true);
+    expect(resultScope.isDone()).toBe(true);
+    expect(result).toMatchObject({
+      success: true,
+      uuid: vessel.uuid,
+      uniqueID,
+      submission: SUCCESS_RESPONSE,
+    });
+    expect(result).toHaveProperty("bytes");
+    expect(result).toHaveProperty("durationMs");
+  });
+
+  test("returns 500 when storage fails", async () => {
+    const uniqueID = toUniqueID(vessel);
+
+    // NOAA should never be called if the data couldn't be stored
+    const noaaScope = nock("https://example.com").post("/geojson").reply(200);
+
+    const s3Scope = nock(s3Env.S3_ENDPOINT)
+      .put(/\.geojson\?x-id=PutObject$/)
+      .reply(403, "<Error><Code>AccessDenied</Code></Error>", {
+        "Content-Type": "application/xml",
+      });
+
+    await postGeoJSON(uniqueID)
+      .expect(500)
+      .expect((res) => {
+        expect(res.body.success).toBe(false);
+      });
+
+    expect(s3Scope.isDone()).toBe(true);
+    expect(noaaScope.isDone()).toBe(false);
+    nock.cleanAll();
+  });
+
+  test("stores failure result when NOAA rejects the submission", async () => {
+    const uniqueID = toUniqueID(vessel);
+
+    const noaaScope = nock("https://example.com")
+      .post("/geojson")
+      .reply(500, { message: "Internal Server Error", success: false });
+
+    const s3Scope = nock(s3Env.S3_ENDPOINT)
+      .put(/\.geojson\?x-id=PutObject$/)
+      .reply(200);
+
+    let result: Record<string, unknown> | undefined;
+    const resultScope = nock(s3Env.S3_ENDPOINT)
+      .put(/\.result\.json\?x-id=PutObject$/, (body) => {
+        result = body as Record<string, unknown>;
+        return true;
+      })
+      .reply(200);
+
+    await postGeoJSON(uniqueID)
+      .expect(502)
+      .expect((res) => {
+        expect(res.body.submissionId).toMatch(
+          new RegExp(`^\\d{4}/\\d{2}/\\d{2}/.*${vessel.uuid}$`),
+        );
+      });
+
+    expect(noaaScope.isDone()).toBe(true);
+    expect(s3Scope.isDone()).toBe(true);
+    expect(resultScope.isDone()).toBe(true);
+    expect(result).toMatchObject({
+      success: false,
+      uuid: vessel.uuid,
+      uniqueID,
+      noaaStatus: 500,
+    });
+    expect(result).toHaveProperty("noaaBody");
+    expect(result).toHaveProperty("message");
   });
 });
 

--- a/packages/signalk-plugin/src/reporters/index.ts
+++ b/packages/signalk-plugin/src/reporters/index.ts
@@ -1,4 +1,4 @@
-import { submitGeoJSON } from "./noaa.js";
+import { submitGeoJSON, describeSubmissionError } from "./noaa.js";
 import { Config } from "../config.js";
 import { ServerAPI } from "@signalk/server-api";
 import { CronJob } from "cron";
@@ -70,9 +70,12 @@ export function createReporter({
       reportLog.logReport(timeframe);
     } catch (err) {
       throw status.error(
-        new Error(`Failed to report to ${url}: ${(err as Error).message}`, {
-          cause: err,
-        }),
+        new Error(
+          `Failed to report to ${url}: ${describeSubmissionError(err)}`,
+          {
+            cause: err,
+          },
+        ),
       );
     }
   }

--- a/packages/signalk-plugin/src/reporters/noaa.ts
+++ b/packages/signalk-plugin/src/reporters/noaa.ts
@@ -50,7 +50,7 @@ export function describeSubmissionError(err: unknown): string {
       // Body is not JSON; fall through to the raw error message
     }
   }
-  return (err as Error).message;
+  return err instanceof Error ? err.message : String(err);
 }
 
 export async function submitFormData(
@@ -87,9 +87,11 @@ export async function submitFormData(
   debug("Received response: %d %s", response.status, response.statusText);
 
   if (!response.ok) {
+    // Keep the body out of the message to avoid nested dumps when errors are
+    // re-reported; it is preserved in err.body and the archived result
     const body = await response.text();
     throw new SubmissionError(
-      `POST to ${url} failed: ${response.status} ${response.statusText}\n${body}`,
+      `POST to ${url} failed: ${response.status} ${response.statusText}`,
       response.status,
       body,
     );

--- a/packages/signalk-plugin/src/reporters/noaa.ts
+++ b/packages/signalk-plugin/src/reporters/noaa.ts
@@ -20,6 +20,39 @@ export type SubmissionResponse = {
   submissionIds: string[];
 };
 
+/** Thrown when the upstream service rejects a submission. */
+export class SubmissionError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+    public body: string,
+  ) {
+    super(message);
+    this.name = "SubmissionError";
+  }
+}
+
+/**
+ * Human-readable summary of a submission failure, surfacing the server's own
+ * error message and submission id (for looking up the archived result) when
+ * the response body is the API's JSON error shape.
+ */
+export function describeSubmissionError(err: unknown): string {
+  if (err instanceof SubmissionError) {
+    try {
+      const { message, submissionId } = JSON.parse(err.body);
+      if (message) {
+        return submissionId
+          ? `${message} (submission: ${submissionId})`
+          : message;
+      }
+    } catch {
+      // Body is not JSON; fall through to the raw error message
+    }
+  }
+  return (err as Error).message;
+}
+
 export async function submitFormData(
   url: URL,
   prefix: string,
@@ -55,8 +88,10 @@ export async function submitFormData(
 
   if (!response.ok) {
     const body = await response.text();
-    throw new Error(
+    throw new SubmissionError(
       `POST to ${url} failed: ${response.status} ${response.statusText}\n${body}`,
+      response.status,
+      body,
     );
   }
 

--- a/packages/signalk-plugin/test/reporters/noaa.test.ts
+++ b/packages/signalk-plugin/test/reporters/noaa.test.ts
@@ -169,5 +169,7 @@ describe("describeSubmissionError", () => {
     expect(describeSubmissionError(new Error("fetch failed"))).toBe(
       "fetch failed",
     );
+    expect(describeSubmissionError("boom")).toBe("boom");
+    expect(describeSubmissionError(undefined)).toBe("undefined");
   });
 });

--- a/packages/signalk-plugin/test/reporters/noaa.test.ts
+++ b/packages/signalk-plugin/test/reporters/noaa.test.ts
@@ -6,6 +6,8 @@ import {
   BATHY_URL,
   submitGeoJSON,
   createGeoJSON,
+  SubmissionError,
+  describeSubmissionError,
 } from "../../src/index.js";
 import { Readable } from "stream";
 import { text } from "stream/consumers";
@@ -129,5 +131,43 @@ describe("createGeoJSON", () => {
     const valid = validate(json);
 
     expect(valid, JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+});
+
+describe("describeSubmissionError", () => {
+  test("surfaces server message and submission id", () => {
+    const err = new SubmissionError(
+      "POST to https://depth.openwaters.io/geojson failed: 502 Bad Gateway",
+      502,
+      JSON.stringify({
+        success: false,
+        message: "POST to NOAA failed: 500 Internal Server Error",
+        submissionId: "2026/07/29/07:11:13.123Z-abc",
+      }),
+    );
+
+    expect(describeSubmissionError(err)).toBe(
+      "POST to NOAA failed: 500 Internal Server Error (submission: 2026/07/29/07:11:13.123Z-abc)",
+    );
+  });
+
+  test("surfaces server message without submission id", () => {
+    const err = new SubmissionError("failed", 500, '{"message":"boom"}');
+    expect(describeSubmissionError(err)).toBe("boom");
+  });
+
+  test("falls back to error message for non-JSON bodies", () => {
+    const err = new SubmissionError(
+      "POST failed: 503",
+      503,
+      "<html>oops</html>",
+    );
+    expect(describeSubmissionError(err)).toBe("POST failed: 503");
+  });
+
+  test("falls back to error message for plain errors", () => {
+    expect(describeSubmissionError(new Error("fetch failed"))).toBe(
+      "fetch failed",
+    );
   });
 });


### PR DESCRIPTION
Vessels have been getting 500s from `POST /geojson` (#102). The failures come from NOAA's CSB ingest endpoint returning 500s, but confirming that was harder than it should be: Vercel's hobby plan keeps about an hour of logs, so by the time a report came in the evidence was gone.

## Changes

The API now stores the upload in R2 before submitting to NOAA, then writes a `<key>.result.json` next to it with the outcome: NOAA's status and response body, duration, and payload size. That gives a permanent per-submission ledger that outlives Vercel's log retention. Storage failures fail the request before NOAA is called, so the client keeps its data and retries.

NOAA rejections now return 502 with the upstream message and a `submissionId` (the storage key) in the response body. 500 now means an actual bug in the API, so the two are distinguishable in the Vercel dashboard.

The plugin parses the server's error response and reports the real message plus the submission id, instead of the nested JSON dump in #102:

```
Failed to report to https://depth.openwaters.io: POST to https://www.ngdc.noaa.gov/... failed: 500 Internal Server Error (submission: 2026/07/29/08:11:34.192Z-<uuid>)
```

That id is the bucket key, so looking up the archived data and result is one `aws s3api get-object` away.

## Known tradeoff

Failed windows are retried by the plugin until they succeed, and each retry stores a new object. Duplicates in the ingest bucket are accepted: date-based keys make it easy to review or delete a day of submissions, and each retry is a superset of the failed attempt, so nothing is lost by keeping them all.