### PR TITLE
Advance report cursor after empty scans

### DIFF
--- a/packages/signalk-plugin/src/reporters/index.ts
+++ b/packages/signalk-plugin/src/reporters/index.ts
@@ -92,6 +92,7 @@ export function createReporter({
       reportLog.lastReport ?? "never",
     );
 
+    if (signal.aborted) return;
     const windows = await source.getAvailableTimeframes(timeframe, windowSize);
     if (signal.aborted) return;
 
@@ -116,6 +117,7 @@ export function createReporter({
   }
 
   function checkpoint(timeframe: Timeframe) {
+    if (signal.aborted) return;
     status.set({ lastReport: timeframe.to });
     reportLog.logReport(timeframe);
   }

--- a/packages/signalk-plugin/src/reporters/index.ts
+++ b/packages/signalk-plugin/src/reporters/index.ts
@@ -56,6 +56,7 @@ export function createReporter({
           timeframe.from,
           timeframe.to,
         );
+        checkpoint(timeframe);
         return;
       }
 
@@ -66,8 +67,7 @@ export function createReporter({
 
       const submission = await submitGeoJSON(url, config, vessel, data);
       app.debug("Submission response: %j", submission);
-      status.set({ lastReport: timeframe.to });
-      reportLog.logReport(timeframe);
+      checkpoint(timeframe);
     } catch (err) {
       throw status.error(
         new Error(
@@ -92,17 +92,32 @@ export function createReporter({
       reportLog.lastReport ?? "never",
     );
 
-    for (const window of await source.getAvailableTimeframes(
-      timeframe,
-      windowSize,
-    )) {
+    const windows = await source.getAvailableTimeframes(timeframe, windowSize);
+    if (signal.aborted) return;
+
+    for (const window of windows) {
       // Stop if plugin is stopped
       if (signal.aborted) return;
 
       await report(window.clamp(timeframe));
     }
 
+    // getAvailableTimeframes intentionally omits empty windows. Once the
+    // complete range has been inspected, advance past those windows too so a
+    // future run does not rescan an ever-growing history range.
+    if (
+      !reportLog.lastReport ||
+      Temporal.Instant.compare(reportLog.lastReport, timeframe.to) < 0
+    ) {
+      checkpoint(timeframe);
+    }
+
     app.debug("Back history reporting complete");
+  }
+
+  function checkpoint(timeframe: Timeframe) {
+    status.set({ lastReport: timeframe.to });
+    reportLog.logReport(timeframe);
   }
 
   function updateStatus() {
@@ -134,6 +149,8 @@ export function createReporter({
   } else {
     reportInBatches().then(start);
   }
+
+  return { report, reportInBatches };
 }
 
 export function createReportLogger(db: DatabaseSync) {

--- a/packages/signalk-plugin/src/status.ts
+++ b/packages/signalk-plugin/src/status.ts
@@ -16,7 +16,7 @@ export function createStatus(app: ServerAPI) {
       [
         state.collecting && "Collecting bathymetry",
         state.usingHistory && "Using history",
-        state.lastReport && `Reported at ${state.lastReport.toString()}`,
+        state.lastReport && `Checked through ${state.lastReport.toString()}`,
         state.nextReport && `Next report at ${state.nextReport.toString()}`,
       ]
         .filter(Boolean)

--- a/packages/signalk-plugin/test/helper.ts
+++ b/packages/signalk-plugin/test/helper.ts
@@ -24,4 +24,5 @@ export const app = {
   error: () => {},
   getDataDirPath: () => "",
   setPluginStatus: () => {},
+  setPluginError: () => {},
 } as unknown as ServerAPI;

--- a/packages/signalk-plugin/test/reporter.test.ts
+++ b/packages/signalk-plugin/test/reporter.test.ts
@@ -1,7 +1,9 @@
-import { expect, test } from "vitest";
-import { createReportLogger } from "../src";
+import { describe, expect, test } from "vitest";
+import { createReporter, createReportLogger, Timeframe } from "../src";
 import { createDB } from "../src/storage";
 import { Temporal } from "@js-temporal/polyfill";
+import { app, config } from "./helper";
+import { createStatus } from "../src/status";
 
 test("logReport", async () => {
   const logger = createReportLogger(createDB(":memory:"));
@@ -11,4 +13,111 @@ test("logReport", async () => {
   expect(logger.lastReport).toBeUndefined();
   logger.logReport!({ from, to });
   expect(logger.lastReport).toEqual(to);
+});
+
+describe("report checkpoints", () => {
+  test("advances after a scan finds no data", async () => {
+    const db = createDB(":memory:");
+    const logger = createReportLogger(db);
+    const now = Temporal.Now.instant();
+    logger.logReport(new Timeframe(now.subtract({ minutes: 1 }), now));
+    const abortController = new AbortController();
+    const reporter = createReporter({
+      app,
+      config,
+      db,
+      status: createStatus(app),
+      signal: abortController.signal,
+      source: {
+        createReader: async () => undefined,
+        getAvailableTimeframes: async () => [],
+      },
+    });
+    const timeframe = new Timeframe(now, now.add({ hours: 6 }));
+
+    await reporter.report(timeframe);
+
+    expect(logger.lastReport?.epochMilliseconds).toBe(
+      timeframe.to.epochMilliseconds,
+    );
+    abortController.abort();
+  });
+
+  test("advances past empty windows after a batch scan", async () => {
+    const db = createDB(":memory:");
+    const logger = createReportLogger(db);
+    const now = Temporal.Now.instant();
+    logger.logReport(new Timeframe(now.subtract({ minutes: 1 }), now));
+    const abortController = new AbortController();
+    const reporter = createReporter({
+      app,
+      config,
+      db,
+      status: createStatus(app),
+      signal: abortController.signal,
+      source: {
+        createReader: async () => undefined,
+        getAvailableTimeframes: async () => [],
+      },
+    });
+    const timeframe = new Timeframe(now, now.add({ hours: 72 }));
+
+    await reporter.reportInBatches(timeframe);
+
+    expect(logger.lastReport?.epochMilliseconds).toBe(
+      timeframe.to.epochMilliseconds,
+    );
+    abortController.abort();
+  });
+
+  test("does not advance when reading data fails", async () => {
+    const db = createDB(":memory:");
+    const logger = createReportLogger(db);
+    const now = Temporal.Now.instant();
+    logger.logReport(new Timeframe(now.subtract({ minutes: 1 }), now));
+    const abortController = new AbortController();
+    const reporter = createReporter({
+      app,
+      config,
+      db,
+      status: createStatus(app),
+      signal: abortController.signal,
+      source: {
+        createReader: async () => {
+          throw new Error("history unavailable");
+        },
+        getAvailableTimeframes: async () => [],
+      },
+    });
+
+    await expect(
+      reporter.report(new Timeframe(now, now.add({ hours: 6 }))),
+    ).rejects.toThrow("history unavailable");
+    expect(logger.lastReport?.epochMilliseconds).toBe(now.epochMilliseconds);
+    abortController.abort();
+  });
+
+  test("does not advance an aborted batch scan", async () => {
+    const db = createDB(":memory:");
+    const logger = createReportLogger(db);
+    const now = Temporal.Now.instant();
+    logger.logReport(new Timeframe(now.subtract({ minutes: 1 }), now));
+    const abortController = new AbortController();
+    const reporter = createReporter({
+      app,
+      config,
+      db,
+      status: createStatus(app),
+      signal: abortController.signal,
+      source: {
+        createReader: async () => undefined,
+        getAvailableTimeframes: async () => [],
+      },
+    });
+    abortController.abort();
+
+    await reporter.reportInBatches(new Timeframe(now, now.add({ hours: 72 })));
+
+    expect(logger.lastReport?.epochMilliseconds).toBe(now.epochMilliseconds);
+  });
 });

--- a/packages/signalk-plugin/test/reporter.test.ts
+++ b/packages/signalk-plugin/test/reporter.test.ts
@@ -103,6 +103,7 @@ describe("report checkpoints", () => {
     const now = Temporal.Now.instant();
     logger.logReport(new Timeframe(now.subtract({ minutes: 1 }), now));
     const abortController = new AbortController();
+    let scanned = false;
     const reporter = createReporter({
       app,
       config,
@@ -111,12 +112,42 @@ describe("report checkpoints", () => {
       signal: abortController.signal,
       source: {
         createReader: async () => undefined,
-        getAvailableTimeframes: async () => [],
+        getAvailableTimeframes: async () => {
+          scanned = true;
+          return [];
+        },
       },
     });
     abortController.abort();
 
     await reporter.reportInBatches(new Timeframe(now, now.add({ hours: 72 })));
+
+    expect(logger.lastReport?.epochMilliseconds).toBe(now.epochMilliseconds);
+    expect(scanned).toBe(false);
+  });
+
+  test("does not advance when aborted during an empty scan", async () => {
+    const db = createDB(":memory:");
+    const logger = createReportLogger(db);
+    const now = Temporal.Now.instant();
+    logger.logReport(new Timeframe(now.subtract({ minutes: 1 }), now));
+    const abortController = new AbortController();
+    const reporter = createReporter({
+      app,
+      config,
+      db,
+      status: createStatus(app),
+      signal: abortController.signal,
+      source: {
+        createReader: async () => {
+          abortController.abort();
+          return undefined;
+        },
+        getAvailableTimeframes: async () => [],
+      },
+    });
+
+    await reporter.report(new Timeframe(now, now.add({ hours: 6 })));
 
     expect(logger.lastReport?.epochMilliseconds).toBe(now.epochMilliseconds);
   });


### PR DESCRIPTION
## What changed

Crowd Depth now records progress after a history scan completes with no bathymetry points. Batch scans also advance past empty windows once the full range has been inspected.

Previously, only a successful submission moved the cursor. When the boat produced no new soundings, every scheduled run queried the entire empty period again. That made the InfluxDB history queries grow on each cycle and occasionally contend with live telemetry writes.

Failed reads, failed submissions, and aborted scans still leave the cursor untouched so they will retry. The plugin status now says "Checked through" because the timestamp can represent either a submission or a completed empty scan.

## Tests

- 69 tests pass
- TypeScript build and package validation pass
- Formatting and lint checks pass